### PR TITLE
Pin msgpack

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ redis>=2.10,<3
 influxdb
 requests<2.28
 certifi<=2020.4.5.1
+msgpack<=1.0.5


### PR DESCRIPTION
Msgpack just dropped python 2 support https://github.com/msgpack/msgpack-python/releases/tag/v1.0.6

Unfortunately for 16.04 hosts we are installing using python 2 (under investigation) so this fails. For now we can pin to the latest version that has python2 support